### PR TITLE
引入CuckooLib, 升级Gradle版本, 使用Gradle引入除gregtech api外的依赖库

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ out
 # gradle
 build
 .gradle
+gradle.properties
 
 # other
 eclipse

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,10 @@
 buildscript {
     repositories {
         jcenter()
-        maven { url = "https://files.minecraftforge.net/maven" }
+        maven {
+            name = 'ForgeMaven'
+            url = 'https://files.minecraftforge.net/maven'
+        }
     }
     dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
@@ -11,34 +14,53 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 
-version = "1.3.2.1"
-group = "com.osir.tmc" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "tmc"
+version = '1.3.2.1'
+group = 'com.osir.tmc' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+archivesBaseName = 'tmc'
 
 sourceCompatibility = targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 compileJava {
     sourceCompatibility = targetCompatibility = '1.8'
 }
 
+repositories {
+    maven {
+        name = 'ChickenBonesMaven'
+        url = 'http://chickenbones.net/maven'
+    }
+    maven {
+        name = 'ForestryMaven'
+        url = 'http://maven.ic2.player.to'
+    }
+    maven {
+        name = 'MTMaven'
+        url = 'https://maven.blamejared.com'
+    }
+    maven {
+        name = 'CuckooMaven'
+        url = 'https://zi-jing.github.io/cuckoo-maven/maven'
+    }
+}
+
 minecraft {
-    version = "1.12.2-14.23.5.2847"
-    runDir = "run"
-    
+    version = '1.12.2-14.23.5.2847'
+    runDir = 'run'
+
     // the mappings can be changed at any time, and must be in the following format.
     // snapshot_YYYYMMDD   snapshot are built nightly.
     // stable_#            stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20171003"
+    mappings = 'snapshot_20171003'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 
 dependencies {
     // you may put jars on which you depend on in ./libs
     // or you may define them like so..
-    //compile "some.group:artifact:version:classifier"
-    //compile "some.group:artifact:version"
-      
+    //compile 'some.group:artifact:version:classifier'
+    //compile 'some.group:artifact:version'
+
     // real examples
     //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
     //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
@@ -55,21 +77,25 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 
+    compile 'codechicken:CodeChickenLib:1.12.2-3.2.2.353:deobf'
+    compile 'net.sengir.forestry:forestry_1.12.2:5.8.2.422:api'
+    compile 'CraftTweaker2:CraftTweaker2-API:4.1.9.6:deobf'
+    compile 'com.github.zi_jing.cuckoolib:CuckooLib:1.0.4'
 }
 
 processResources {
     // this will ensure that this task is redone when the versions change.
-    inputs.property "version", project.version
-    inputs.property "mcversion", project.minecraft.version
+    inputs.property 'version', project.version
+    inputs.property 'mcversion', project.minecraft.version
 
     // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info'
-                
+
         // replace version and mcversion
-        expand 'version':project.version, 'mcversion':project.minecraft.version
+        expand 'version': project.version, 'mcversion': project.minecraft.version
     }
-        
+
     // copy everything else except the mcmod.info
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'
@@ -85,4 +111,10 @@ task apiJar(type: Jar) {
 
 artifacts {
     archives apiJar
+}
+
+// 强制UTF-8构建
+compileJava.options.encoding = 'UTF-8'
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,0 @@
-# Sets default memory used for gradle commands. Can be overridden by user or command line properties.
-# This is required to provide enough memory for the Minecraft decompilation process.
-org.gradle.jvmargs=-Xmx3G

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,12 @@
+rootProject.name = 'Terra-Metal-Craft'
+
+Properties properties = new Properties()
+String includeBuildPropKey = 'CuckooLibIncludeBuildPath'
+File propFile = new File(rootProject.projectDir.getPath() + File.separator + 'gradle.properties')
+if (propFile.exists()) {
+    properties.load(new StringReader(propFile.text))
+}
+
+if (properties.containsKey(includeBuildPropKey)) {
+    includeBuild(properties.getProperty(includeBuildPropKey))
+}

--- a/src/main/java/com/osir/tmc/item/ModMetaTool.java
+++ b/src/main/java/com/osir/tmc/item/ModMetaTool.java
@@ -2,7 +2,7 @@ package com.osir.tmc.item;
 
 import gregtech.api.items.toolitem.ToolMetaItem;
 
-public class ModMetaTool extends ToolMetaItem<ToolMetaItem.MetaToolValueItem> {
+public class ModMetaTool extends ToolMetaItem<ToolMetaItem<?>.MetaToolValueItem> {
 	@Override
 	public void registerSubItems() {
 


### PR DESCRIPTION
### 更改详细信息：
- 引入CuckooLib: 引入CuckooLib库，并实现复合构建，设置方法：[链接](https://github.com/gonggongjohn/EOK-1.12/blob/master/README-zh_cn.md#与CuckooLib协同开发)
- 升级Gradle版本到4.10，因为Gradle 2.14不支持复合构建
- 使用Gradle引入了依赖库：
    - `codechicken:CodeChickenLib:1.12.2-3.2.2.353:deobf`
    - `net.sengir.forestry:forestry_1.12.2:5.8.2.422:api`
    - `CraftTweaker2:CraftTweaker2-API:4.1.9.6:deobf`
    - `com.github.zi_jing.cuckoolib:CuckooLib:1.0.4`
    **GTCE api未使用Gradle引入，只能通过手动将jar归档放入libs/目录来引入；其他已引入的库无须放入libs/目录。**
    使用Gradle引入依赖库同时还解决了查看源码时没有Javadoc以及出现Srg Name的问题。
- 修复了[ModMetaTool.java第5行](https://github.com/Os-Ir/Terra-Metal-Craft/blob/2a96c74ad35f68384392463c195aea56210d101b/src/main/java/com/osir/tmc/item/ModMetaTool.java#L5)的一个编译错误
- 删除文件[gradle.properties](https://github.com/Os-Ir/Terra-Metal-Craft/blob/2a96c74ad35f68384392463c195aea56210d101b/gradle.properties)，因为它是被用来存储不应被添加至版本控制系统的设置的
- 强制使用UTF-8构建项目
- 修正build.gradle代码风格
### 测试详细信息：
测试已通过，测试项目：
- 构建
- 运行

测试所用的Mods：
- The One Probe: 1.12-1.4.28
- TOP Addons: 1.12.2-1.10.1
- Forestry For Minecraft: 1.12.2-5.8.2.422
- GregTech Community Edition: 1.12.2-1.9.0.481
- Just Enough Items: 1.12.2-4.15.0.291